### PR TITLE
Large structural change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ multi_inventory.yaml
 .tags*
 ose3-installer
 infrastructure.json
+*.log
+reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/*.json

--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -58,7 +58,6 @@ export AWS_SECRET_ACCESS_KEY=bar
 ### Region
 The default region is us-east-1 but can be changed when running the ose-on-aws script by specifying --region=us-west-2 for example. The region must contain at least 3 Availability Zones. 
 
-=======
 ### Environment
 The default environment descriptor file is`playbooks/vars/main.yaml`. To use a different environment file, add `--vars-file=/PATH/TO/VARS/FILE.yaml`. Either a fully qualified path or relative to playbooks/
 You must set a new stack name if you define a custom environment, use `--stack-name=STACK_NAME`
@@ -83,7 +82,7 @@ Once deployed, you can alter the instance counts up and down. CloudFormation wil
 
 ### Extendable CloudFormation Templates
 You can extend the AWS resources deployed at stack creation time by supplying a path to a json fragment. It **MUST** contain valid CloudFormation json. The contents of the file run thru the jinja templating engine before being merged, at the root level, into the default CloudFormation template. Use `--custom-template=/PATH/TO/TEMPLATE/FILE.json
-See the README and examples in extensions/examples/
+See the README in extensions/examples/
 
 ### AMI ID
 The AMI ID may need to change if the AWS IAM account does not have access to the Red Hat Cloud Access gold image or if deploying outside of the us-east-1 region.

--- a/reference-architecture/aws-ansible/extensions/examples/README
+++ b/reference-architecture/aws-ansible/extensions/examples/README
@@ -1,0 +1,14 @@
+# Extensions
+A collection of AWS CloudFormation snippets that can be merged into the main template at runtime.
+My use case is to deploy rds instances. Anything you can create with cfn is valid.
+Any snippet needs to be a valid cfn json template. Because its merged before being applied to AWS, it has has access to the same AWS Parameters and jinja variables.
+
+**WARNING**
+With great power comes great responsibility.
+Your snippet will be deep merged at the root level with the default cfn template.
+This means its entirely possible for you to overwrite some defaults. This is a bad idea and will lkely end in and incomplete or broken deployment.
+The intent is that you use this feature to deploy *additional* aws resources.
+
+If you declare a resource that is already declared in the default template, it will be merged. This means that both values could be present once merging is complete.
+
+To use a snippet add `--custom-template=/PATH/TO/YOUR/SNIPPET.json`

--- a/reference-architecture/aws-ansible/playbooks/infrastructure.yaml
+++ b/reference-architecture/aws-ansible/playbooks/infrastructure.yaml
@@ -3,7 +3,7 @@
   gather_facts: no
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   vars:
     vpc_subnet_azs: "{{ lookup('ec2_zones_by_region', region) }}"
   roles:

--- a/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
@@ -3,7 +3,7 @@
   gather_facts: no
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       # Group systems
       - instance-groups
@@ -13,7 +13,7 @@
   gather_facts: no
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - host-up
       
@@ -23,7 +23,7 @@
   serial: 1
   user: ec2-user
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - rhsm-subscription
       
@@ -32,7 +32,7 @@
   become: yes
   user: ec2-user
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - rhsm-repos
       - prerequisites
@@ -44,7 +44,7 @@
   gather_facts: yes
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - s3-registry-user
       - s3-registry-bucket
@@ -53,7 +53,7 @@
   gather_facts: no
   become: yes
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - openshift-emptydir-quota
       
@@ -61,6 +61,6 @@
   gather_facts: no 
   become: yes
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - openshift-registry

--- a/reference-architecture/aws-ansible/playbooks/openshift-setup.yaml
+++ b/reference-architecture/aws-ansible/playbooks/openshift-setup.yaml
@@ -30,6 +30,16 @@
     osm_default_subdomain: "{{ wildcard_zone }}"
     osm_default_node_selector: "role=app"
     deployment_type: openshift-enterprise
+    ##openshift_master_identity_providers:
+    ##  - name: basic_auth
+    ##    login: true
+    ##    challenge: true
+    ##    kind: HTPasswdPasswordIdentityProvider
+    ##    filename: /etc/origin/master/htpasswd
+    ##openshift_master_htpasswd_users:
+    ##  admin: "$apr1$L5rUd2yB$SlWgOZhtrz1XjkjB/Zhnf/"
+    #osm_use_cockpit: true
+    #containerized: false
     openshift_master_identity_providers:
     - name: github
       kind: GitHubIdentityProvider

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2
@@ -1,9 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {
-    "VpcCidrBlock": {
-      "Type": "String"
-    },
     "VpcName": {
       "Type": "String",
       "Default": "ose-on-aws"
@@ -20,9 +17,6 @@
     "PublicHostedZone": {
       "Type": "String"
     },
-    "Region": {
-      "Type": "String"
-    },
     "MasterClusterPublicHostname": {
       "Type": "String"
     },
@@ -31,12 +25,6 @@
     },
     "AppWildcardDomain": {
       "Type": "String"
-    },
-    "SubnetAvailabilityZones": {
-      "Type": "List<AWS::EC2::AvailabilityZone::Name>"
-    },
-    "SubnetCidrBlocks": {
-      "Type": "CommaDelimitedList"
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName"
@@ -48,21 +36,6 @@
     "AmiId": {
       "Type": "AWS::EC2::Image::Id"
     },
-    "BastionInstanceType": {
-      "Type": "String",
-      "Default": "t2.micro"
-    },
-    "BastionRootVolSize": {
-      "Type": "String",
-      "Default": "30"
-    },
-    "BastionRootVolType": {
-      "Type": "String",
-      "Default": "gp2"
-    },
-    "BastionUserData": {
-      "Type": "String"
-    },
     "MasterRootVolSize": {
       "Type": "String",
       "Default": "10"
@@ -71,12 +44,12 @@
       "Type": "String",
       "Default": "25"
     },
+    "MasterUserData": {
+      "Type": "String"
+    },
     "MasterEtcdVolSize": {
       "Type": "String",
       "Default": "25"
-    },
-    "MasterUserData": {
-      "Type": "String"
     },
     "MasterEtcdVolType": {
       "Type": "String",
@@ -118,9 +91,6 @@
       "Type": "String",
       "Default": "30"
     },
-    "NodeUserData": {
-      "Type": "String"
-    },
     "NodeDockerVolSize": {
       "Type": "String",
       "Default": "25"
@@ -128,6 +98,9 @@
     "NodeDockerVolType": {
       "Type": "String",
       "Default": "gp2"
+    },
+    "NodeUserData": {
+      "Type": "String"
     },
     "NodeEmptyVolSize": {
       "Type": "String",
@@ -140,229 +113,33 @@
     "NodeRootVolType": {
       "Type": "String",
       "Default": "gp2"
-    }
-  },
-  "Conditions": {
-    "CreateDhcpOpts": {"Fn::Equals" : [{"Ref" : "Region"}, "us-east-1"]}
-  },
-  "Resources": {
+    },
     "Vpc": {
-      "Type": "AWS::EC2::VPC",
-      "Properties": {
-        "CidrBlock": { "Ref": "VpcCidrBlock" },
-        "EnableDnsSupport": "true",
-        "EnableDnsHostnames": "true",
-        "Tags": [ { "Key": "Name", "Value": { "Ref": "VpcName" } } ]
-      }
+      "Type": "String"
     },
-    "VpcInternetGateway": {
-      "Type": "AWS::EC2::InternetGateway",
-      "Properties": {}
-    },
-    "VpcGA": {
-      "Type": "AWS::EC2::VPCGatewayAttachment",
-      "Properties": {
-        "InternetGatewayId": { "Ref": "VpcInternetGateway" },
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "VpcRouteTable": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PrivateRouteTable": {
-      "DependsOn": ["Nat"],
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "VPCRouteInternetGateway": {
-      "Type": "AWS::EC2::Route",
-      "Properties": {
-        "GatewayId": { "Ref": "VpcInternetGateway" },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "RouteTableId": { "Ref": "VpcRouteTable" }
-      }
-    },
-    "EIP" : {
-       "Type" : "AWS::EC2::EIP",
-       "Properties" : {
-          "Domain" : "vpc"
-      }
-    },
-    "Route" : {
-      "DependsOn": ["Nat"],
-      "Type" : "AWS::EC2::Route",
-      "Properties" : {
-         "RouteTableId" : { "Ref" : "PrivateRouteTable" },
-         "DestinationCidrBlock" : "0.0.0.0/0",
-         "NatGatewayId" : { "Ref" : "Nat" }
-      }
-     },
     "PublicSubnet1": {
-      "Type": "AWS::EC2::Subnet",
-      "DependsOn": ["Vpc"],
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["0", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["0", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Public_Subnet_1"} ],
-        "MapPublicIpOnLaunch": "true",
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PublicSubnet1RTA": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "RouteTableId": { "Ref": "VpcRouteTable" },
-        "SubnetId": { "Ref": "PublicSubnet1" }
-      }
+      "Type": "String"
     },
     "PublicSubnet2": {
-      "Type": "AWS::EC2::Subnet",
-      "DependsOn": ["Vpc"],
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["1", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["1", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Public_Subnet_2"} ],
-        "MapPublicIpOnLaunch": "true",
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PublicSubnet2RTA": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "RouteTableId": { "Ref": "VpcRouteTable" },
-        "SubnetId": { "Ref": "PublicSubnet2" }
-      }
+      "Type": "String"
     },
     "PublicSubnet3": {
-      "Type": "AWS::EC2::Subnet",
-      "DependsOn": ["Vpc"],
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["2", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["2", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Public_Subnet_3"} ],
-        "MapPublicIpOnLaunch": "true",
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PublicSubnet3RTA": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "RouteTableId": { "Ref": "VpcRouteTable" },
-        "SubnetId": { "Ref": "PublicSubnet3" }
-      }
+      "Type": "String"
     },
     "PrivateSubnet1": {
-      "DependsOn": ["Nat"],
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["0", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["3", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Private_Subnet_1"} ],
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PrivateSubnet1RTA" : {
-      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties" : {
-         "SubnetId" : { "Ref" : "PrivateSubnet1" },
-         "RouteTableId" : { "Ref" : "PrivateRouteTable" }
-      }
+      "Type": "String"
     },
     "PrivateSubnet2": {
-      "DependsOn": ["Nat"],
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["1", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["4", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Private_Subnet_2"} ],
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PrivateSubnet2RTA" : {
-      "DependsOn": ["Nat"],
-      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties" : {
-         "SubnetId" : { "Ref" : "PrivateSubnet2" },
-         "RouteTableId" : { "Ref" : "PrivateRouteTable" }
-      }
+      "Type": "String"
     },
     "PrivateSubnet3": {
-      "DependsOn": ["Nat"],
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "AvailabilityZone": {"Fn::Select": ["2", {"Ref": "SubnetAvailabilityZones"}]},
-        "CidrBlock": {"Fn::Select": ["5", {"Ref": "SubnetCidrBlocks"}]},
-        "Tags": [ {"Key": "Name", "Value": "Private_Subnet_3"} ],
-        "VpcId": { "Ref": "Vpc" }
-      }
-    },
-    "PrivateSubnet3RTA" : {
-       "Type" : "AWS::EC2::SubnetRouteTableAssociation",
-       "Properties" : {
-          "SubnetId" : { "Ref" : "PrivateSubnet3" },
-          "RouteTableId" : { "Ref" : "PrivateRouteTable" }
-      }
-    },
-    "Nat" : {
-      "DependsOn": ["EIP"],
-      "Type" : "AWS::EC2::NatGateway",
-      "Properties" : {
-          "AllocationId" : { "Fn::GetAtt" : ["EIP", "AllocationId"]},
-          "SubnetId" : { "Ref" : "PublicSubnet1"}
-      }
-    },
-    "EIP" : {
-       "Type" : "AWS::EC2::EIP",
-       "Properties" : {
-          "Domain" : "vpc"
-      }
-    },
-    "Route" : {
-      "DependsOn": ["Nat"],
-      "Type" : "AWS::EC2::Route",
-      "Properties" : {
-         "RouteTableId" : { "Ref" : "PrivateRouteTable" },
-         "DestinationCidrBlock" : "0.0.0.0/0",
-         "NatGatewayId" : { "Ref" : "Nat" }
-      }
-     },
-    "DHCPOpts" : {
-      "Type" : "AWS::EC2::DHCPOptions",
-      "Condition": "CreateDhcpOpts",
-      "Properties" : {
-        "DomainName": "ec2.internal",
-        "DomainNameServers": [ "AmazonProvidedDNS" ]
-      }
-    },
-    "AssociateOpts" : {
-      "Type" : "AWS::EC2::VPCDHCPOptionsAssociation",
-      "Condition": "CreateDhcpOpts",
-      "Properties" : {
-          "VpcId": { "Ref" : "Vpc" },
-          "DhcpOptionsId": { "Ref" : "DHCPOpts" }
-      }
+      "Type": "String"
     },
     "BastionSg": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "bastion-sg",
-        "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "bastion_sg"} ],
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
+      "Type": "String"
+    }
+  },
+  "Resources": {
     "EtcdSG": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -548,7 +325,7 @@
         "IpProtocol": "tcp",
         "FromPort": "22",
         "ToPort": "22",
-        "SourceSecurityGroupId": { "Fn::GetAtt": [ "BastionSg", "GroupId" ] }
+        "SourceSecurityGroupId": {"Ref": "BastionSg"}
       }
     },
     "MasterIngressIntLB": {
@@ -669,9 +446,12 @@
           {"Ref": "PrivateSubnet3"}
             ],
         "Instances": [
-          {"Ref": "Master01"},
-          {"Ref": "Master02"},
-          {"Ref": "Master03"}
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
             ]
         }
     },
@@ -702,9 +482,12 @@
           {"Ref": "PublicSubnet3"}
             ],
         "Instances": [
-          {"Ref": "Master01"},
-          {"Ref": "Master02"},
-          {"Ref": "Master03"}
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
             ]
       }
     },
@@ -741,8 +524,12 @@
           {"Ref": "PublicSubnet3"}
         	],
         "Instances": [
-          {"Ref": "InfraNode01"},
-          {"Ref": "InfraNode02"}
+{% for idx in range(1, infra_count) %}
+          {"Ref": "InfraNode{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
             ]
       }
     },
@@ -771,7 +558,7 @@
                      "ec2:Describe*",
                      "ec2:AttachVolume",
                      "ec2:DetachVolume"
-                  ],
+                  ], 
                   "Resource": "*"
                 }
               ]
@@ -815,14 +602,12 @@
     },
     "MasterInstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
-      "DependsOn": "MasterPolicy",
       "Properties": {
         "Roles": [ { "Ref": "MasterPolicy" } ]
       }
     },
     "NodeInstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
-      "DependsOn": "NodePolicy",
       "Properties": {
         "Roles": [ { "Ref": "NodePolicy" } ]
       }
@@ -832,10 +617,9 @@
       "DependsOn": [
         "InfraElb",
         "MasterIntElb",
-        "Master01",
-        "Master02",
-        "Master03",
-        "Bastion",
+{% for idx in range(1, master_count) %}
+        "Master{{ '%02d' % idx }}",
+{% endfor %}
         "MasterExtElb"
       ],
       "Properties": {
@@ -865,258 +649,109 @@
                 "DNSName": { "Fn::GetAtt" : ["InfraElb","CanonicalHostedZoneName"] }
             }
           },
+{% for idx in range(1, master_count) %}
           {
-            "Name": {"Fn::Join": [".", ["bastion",{"Ref": "Route53HostedZone"}]]},
+            "Name": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
             "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Bastion", "PublicIp"] }]
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["Master{{ '%02d' % idx }}", "PrivateIp"] }]
+          },
+{% endfor %}
+{% for idx in range(1, infra_count) %}
+          {
+            "Name": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode{{ '%02d' % idx }}", "PrivateIp"] }]
+          },
+{% endfor %}
+{% for idx in range(1, node_count) %}
+          {
+            "Name": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+             "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode{{ '%03d' % idx }}", "PrivateIp"] }]
+          }
+  {% if not loop.last %}
+           ,
+  {% endif %}
+{% endfor %}
+        ]
+      }
+    },
+{% for idx in range(1, master_count) %}
+    "Master{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["MasterInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "MasterUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "MasterInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "master"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterRootVolSize"},
+              "VolumeType": {"Ref": "MasterRootVolType"}
+            }
           },
           {
-            "Name": {"Fn::Join": [".", ["ose-master01",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master01", "PrivateIp"] }]
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterDockerVolSize"},
+              "VolumeType": {"Ref": "MasterDockerVolType"}
+            }
           },
           {
-            "Name": {"Fn::Join": [".", ["ose-master02",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master02", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-master03",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master03", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-infra-node01",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode01", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-infra-node02",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode02", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-app-node01",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode01", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-app-node02",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode02", "PrivateIp"] }]
+            "DeviceName": "/dev/xvdc",
+            "Ebs": {
+              "DeleteOnTermination": "false",
+              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
+              "VolumeType": {"Ref": "MasterEtcdVolType"}
+            }
           }
         ]
       }
     },
-    "Bastion" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "BastionUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "BastionInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["BastionSg", "GroupId"] }],
-          "SubnetId" : {"Ref": "PublicSubnet1"},
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["bastion",{"Ref": "PublicHostedZone"}]]}
-            }
-          ],
-          "BlockDeviceMappings" : [
-			          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "BastionRootVolSize"},
-              "VolumeType": {"Ref": "BastionRootVolType"}
-                   }
-            }
-          ]
-       }
-    },
-    "BastionEip" : {
-       "Type" : "AWS::EC2::EIP",
-        "Properties" : {
-        "Domain" : "vpc"
-           }
-       },
-    "BastionEipAssoc" : {
-      "DependsOn": ["Bastion"],
-      "Type" : "AWS::EC2::EIPAssociation",
+{% endfor %}
+{% for idx in range(1, infra_count) %}
+    "InfraNode{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
       "Properties" : {
-        "InstanceId" : {"Ref" : "Bastion"},
-        "AllocationId" : { "Fn::GetAtt" : ["BastionEip", "AllocationId"]}
-        }
-       },
-    "Master01" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["MasterInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "MasterInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "InfraInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
           },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
+          { "Key": "openshift-role",
+            "Value": "infra"
           }
-         ]
-     }
-  },
-    "Master02" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["MasterInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-          "InstanceType": {"Ref": "MasterInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
-          }
-         ]
-     }
-   },
-    "Master03" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["MasterInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	  "InstanceType": {"Ref": "MasterInstanceType"},
-	  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet3"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master03",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
-          }
-         ]
-     }
-   },
-    "InfraNode01" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["NodeInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	  "InstanceType": {"Ref": "InfraInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-          "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-infra-node01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "infra"
-            }
-          ],
-          "BlockDeviceMappings" : [
+        ],
+        "BlockDeviceMappings" : [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
@@ -1141,29 +776,31 @@
               "VolumeType": {"Ref": "NodeEmptyVolType"}
             }
           }
-         ]
-     }
+        ]
+      }
     },
-    "InfraNode02" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["NodeInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-          "InstanceType": {"Ref": "InfraInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-          "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-infra-node02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "infra"
-            }
-          ],
-          "BlockDeviceMappings" : [
+{% endfor %}
+{% for idx in range(1, node_count) %}
+    "AppNode{{ '%03d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "AppNodeInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "app"
+          }
+        ],
+        "BlockDeviceMappings" : [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
@@ -1188,102 +825,12 @@
               "VolumeType": {"Ref": "NodeEmptyVolType"}
             }
           }
-         ]
-     }
- },
-    "AppNode01" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["NodeInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-          "InstanceType": {"Ref": "AppNodeInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-          "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-app-node01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "app"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeRootVolSize"},
-              "VolumeType": {"Ref": "NodeRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeDockerVolSize"},
-              "VolumeType": {"Ref": "NodeDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
-              "VolumeType": {"Ref": "NodeEmptyVolType"}
-            }
-          }
-         ]
-     }
- },
-    "AppNode02" : {
-       "Type" : "AWS::EC2::Instance",
-       "DependsOn": ["NodeInstanceProfile"],
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-          "InstanceType": {"Ref": "AppNodeInstanceType"},
-	  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-	  "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-app-node02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "app"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeRootVolSize"},
-              "VolumeType": {"Ref": "NodeRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeDockerVolSize"},
-              "VolumeType": {"Ref": "NodeDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
-              "VolumeType": {"Ref": "NodeEmptyVolType"}
-            }
-          }
-         ]
-     }
-   }
- }
+        ]
+      }
+    }
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+  }
 }

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json.j2
@@ -1,0 +1,908 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": {
+    "VpcName": {
+      "Type": "String",
+      "Default": "ose-on-aws"
+    },
+    "MasterApiPort": {
+      "Type": "Number"
+    },
+    "MasterHealthTarget": {
+      "Type": "String"
+    },
+    "Route53HostedZone": {
+      "Type": "String"
+    },
+    "PublicHostedZone": {
+      "Type": "String"
+    },
+    "MasterClusterPublicHostname": {
+      "Type": "String"
+    },
+    "MasterClusterHostname": {
+      "Type": "String"
+    },
+    "AppWildcardDomain": {
+      "Type": "String"
+    },
+    "KeyName": {
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "MasterInstanceType": {
+      "Type": "String",
+      "Default": "t2.medium"
+    },
+    "AmiId": {
+      "Type": "AWS::EC2::Image::Id"
+    },
+    "BastionInstanceType": {
+      "Type": "String",
+      "Default": "t2.micro"
+    },
+    "BastionRootVolSize": {
+      "Type": "String",
+      "Default": "30"
+    },
+    "BastionRootVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "BastionUserData": {
+      "Type": "String"
+    },
+    "MasterRootVolSize": {
+      "Type": "String",
+      "Default": "10"
+    },
+    "MasterDockerVolSize": {
+      "Type": "String",
+      "Default": "25"
+    },
+    "MasterEtcdVolSize": {
+      "Type": "String",
+      "Default": "25"
+    },
+    "MasterEtcdVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "MasterUserData": {
+      "Type": "String"
+    },
+    "MasterDockerVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "MasterRootVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "InfraInstanceType": {
+      "Type": "String",
+      "Default": "t2.medium"
+    },
+    "InfraRootVolSize": {
+      "Type": "String",
+      "Default": "30"
+    },
+    "InfraDockerVolSize": {
+      "Type": "String",
+      "Default": "25"
+    },
+    "InfraDockerVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "InfraRootVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "AppNodeInstanceType": {
+      "Type": "String",
+      "Default": "t2.medium"
+    },
+    "NodeRootVolSize": {
+      "Type": "String",
+      "Default": "30"
+    },
+    "NodeUserData": {
+      "Type": "String"
+    },
+    "NodeDockerVolSize": {
+      "Type": "String",
+      "Default": "25"
+    },
+    "NodeDockerVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "NodeEmptyVolSize": {
+      "Type": "String",
+      "Default": "25"
+    },
+    "NodeEmptyVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "NodeRootVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "Vpc": {
+      "Type": "String"
+    },
+    "PublicSubnet1": {
+      "Type": "String"
+    },
+    "PublicSubnet2": {
+      "Type": "String"
+    },
+    "PublicSubnet3": {
+      "Type": "String"
+    },
+    "PrivateSubnet1": {
+      "Type": "String"
+    },
+    "PrivateSubnet2": {
+      "Type": "String"
+    },
+    "PrivateSubnet3": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "BastionSg": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "bastion-sg",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "bastion_sg"} ],
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "EtcdSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "etcd",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_etcd_sg"} ]
+      }
+    },
+    "InfraElbSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Infra Load Balancer",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_router_sg"} ],
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "MasterExtElbSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Master External Load Balancer",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_elb_master_sg"} ],
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": { "Ref": "MasterApiPort" },
+            "ToPort": { "Ref": "MasterApiPort" },
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "MasterIntElbSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Master Internal Load Balancer",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_internal_elb_master_sg"} ]
+      }
+    },
+    "InfraSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Infra",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_infra_node_sg"} ]
+      }
+    },
+    "NodeSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Node",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_node_sg"} ]
+      }
+    },
+    "MasterSG": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Master",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [ {"Key": "Name", "Value": "ose_master_sg"} ]
+      }
+    },
+    "InfraElbEgressHTTP": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "InfraElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "80",
+        "ToPort": "80",
+        "DestinationSecurityGroupId": { "Fn::GetAtt": [ "InfraSG", "GroupId" ] }
+      }
+    },
+    "InfraElbEgressHTTPS": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "InfraElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "443",
+        "ToPort": "443",
+        "DestinationSecurityGroupId": { "Fn::GetAtt": [ "InfraSG", "GroupId" ] }
+      }
+    },
+    "MasterExtElbEgressAPI": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterExtElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "DestinationSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "MasterIntElbEgressAPI": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterIntElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "DestinationSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "MasterIntElbIngressMasters": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterIntElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "MasterIntElbIngressNodes": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterIntElbSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "InfraIngressHTTP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "InfraSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "80",
+        "ToPort": "80",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "InfraElbSG", "GroupId" ] }
+      }
+    },
+    "InfraIngressHTTPS": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "InfraSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "443",
+        "ToPort": "443",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "InfraElbSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressMasterKubelet": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "10250",
+        "ToPort": "10250",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressNodeVXLAN": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "udp",
+        "FromPort": "4789",
+        "ToPort": "4789",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressSsh": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "22",
+        "ToPort": "22",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "BastionSg", "GroupId" ] }
+      }
+    },
+    "MasterIngressIntLB": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterIntElbSG", "GroupId" ] }
+      }
+    },
+    "MasterIngressExtLB": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterExtElbSG", "GroupId" ] }
+      }
+    },
+    "MasterIngressNodesDNSUDP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "udp",
+        "FromPort": "8053",
+        "ToPort": "8053",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "MasterIngressNodesDNSTCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "8053",
+        "ToPort": "8053",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "MasterIngressNodesAPITCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "MasterIngressMastersAPITCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "MasterApiPort" },
+        "ToPort": { "Ref": "MasterApiPort" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "EtcdIngressEtcd": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "EtcdSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "2379",
+        "ToPort": "2379",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "EtcdSG", "GroupId" ] }
+      }
+    },
+    "EtcdIngressMasters": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "EtcdSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "2379",
+        "ToPort": "2379",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "EtcdIngressEtcdPeer": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "EtcdSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "2380",
+        "ToPort": "2380",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "EtcdSG", "GroupId" ] }
+      }
+    },
+    "MasterIntElb": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "CrossZone": "true",
+        "Tags": [ {"Key": "Name", "Value": "ose_internal_master_elb"} ],
+        "HealthCheck": {
+          "HealthyThreshold" : "2",
+          "Interval" : "5",
+          "Target" : { "Ref": "MasterHealthTarget" },
+          "Timeout" : "2",
+          "UnhealthyThreshold" : "2"
+        },
+        "Listeners":[
+          {
+            "InstancePort": { "Ref" : "MasterApiPort" },
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": { "Ref" : "MasterApiPort" },
+            "Protocol": "TCP"
+          }
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": [ { "Ref": "MasterIntElbSG" } ],
+        "Subnets": [
+          {"Ref": "PrivateSubnet1"},
+          {"Ref": "PrivateSubnet2"},
+          {"Ref": "PrivateSubnet3"}
+            ],
+        "Instances": [
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+            ]
+        }
+    },
+    "MasterExtElb": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "CrossZone": "true",
+        "Tags": [ {"Key": "Name", "Value": "ose_master_elb"} ],
+        "HealthCheck": {
+          "HealthyThreshold" : "2",
+          "Interval" : "5",
+          "Target" : { "Ref": "MasterHealthTarget" },
+          "Timeout" : "2",
+          "UnhealthyThreshold" : "2"
+        },
+        "Listeners":[
+          {
+            "InstancePort": { "Ref" : "MasterApiPort" },
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": { "Ref" : "MasterApiPort" },
+            "Protocol": "TCP"
+          }
+        ],
+        "SecurityGroups": [{"Ref": "MasterExtElbSG"}],
+        "Subnets": [
+          {"Ref": "PublicSubnet1"},
+          {"Ref": "PublicSubnet2"},
+          {"Ref": "PublicSubnet3"}
+            ],
+        "Instances": [
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+            ]
+      }
+    },
+    "InfraElb": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "CrossZone": "true",
+        "Tags": [ {"Key": "Name", "Value": "ose_router_elb"} ],
+        "HealthCheck": {
+          "HealthyThreshold" : "2",
+          "Interval" : "5",
+          "Target" : "TCP:443",
+          "Timeout" : "2",
+          "UnhealthyThreshold" : "2"
+        },
+        "Listeners":[
+          {
+            "InstancePort": "443",
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": "443",
+            "Protocol": "TCP"
+          },
+          {
+            "InstancePort": "80",
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": "80",
+            "Protocol": "TCP"
+          }
+        ],
+        "SecurityGroups": [ { "Ref": "InfraElbSG" } ],
+        "Subnets": [
+          {"Ref": "PublicSubnet1"},
+          {"Ref": "PublicSubnet2"},
+          {"Ref": "PublicSubnet3"}
+        	],
+        "Instances": [
+{% for idx in range(1, infra_count) %}
+          {"Ref": "InfraNode{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+            ]
+      }
+    },
+    "NodePolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Service": [ "ec2.amazonaws.com" ] },
+              "Action": [ "sts:AssumeRole" ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "node-describe",
+            "PolicyDocument": {
+              "Version" : "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                     "ec2:Describe*",
+                     "ec2:AttachVolume",
+                     "ec2:DetachVolume"
+                  ], 
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "MasterPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Service": [ "ec2.amazonaws.com" ] },
+              "Action": [ "sts:AssumeRole" ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "master-ec2-all",
+            "PolicyDocument": {
+              "Version" : "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                     "ec2:*",
+                     "elasticloadbalancing:*"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "MasterInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Roles": [ { "Ref": "MasterPolicy" } ]
+      }
+    },
+    "NodeInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Roles": [ { "Ref": "NodePolicy" } ]
+      }
+    },
+    "Route53Records": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "DependsOn": [
+        "InfraElb",
+        "MasterIntElb",
+        "Bastion",
+{% for idx in range(1, master_count) %}
+        "Master{{ '%02d' % idx }}",
+{% endfor %}
+        "MasterExtElb"
+      ],
+      "Properties": {
+        "HostedZoneName": { "Ref": "Route53HostedZone" },
+        "RecordSets": [
+          {
+            "Name":  { "Ref": "MasterClusterPublicHostname" },
+            "Type": "A",
+            "AliasTarget": {
+                "HostedZoneId": { "Fn::GetAtt" : ["MasterExtElb", "CanonicalHostedZoneNameID"] },
+                "DNSName": { "Fn::GetAtt" : ["MasterExtElb","CanonicalHostedZoneName"] }
+            }
+          },
+          {
+            "Name": { "Ref": "MasterClusterHostname" },
+            "Type": "A",
+            "AliasTarget": {
+                "HostedZoneId": { "Fn::GetAtt" : ["MasterIntElb", "CanonicalHostedZoneNameID"] },
+                "DNSName": { "Fn::GetAtt" : ["MasterIntElb","DNSName"] }
+            }
+          },
+          {
+            "Name": { "Ref": "AppWildcardDomain" },
+            "Type": "A",
+            "AliasTarget": {
+                "HostedZoneId": { "Fn::GetAtt" : ["InfraElb", "CanonicalHostedZoneNameID"] },
+                "DNSName": { "Fn::GetAtt" : ["InfraElb","CanonicalHostedZoneName"] }
+            }
+          },
+{% for idx in range(1, master_count) %}
+          {
+            "Name": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["Master{{ '%02d' % idx }}", "PrivateIp"] }]
+          },
+{% endfor %}
+{% for idx in range(1, infra_count) %}
+          {
+            "Name": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode{{ '%02d' % idx }}", "PrivateIp"] }]
+          },
+{% endfor %}
+{% for idx in range(1, node_count) %}
+          {
+            "Name": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+             "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode{{ '%03d' % idx }}", "PrivateIp"] }]
+          },
+{% endfor %}
+          {
+            "Name": {"Fn::Join": [".", ["bastion",{"Ref": "Route53HostedZone"}]]},
+            "Type": "A",
+			"TTL": "300",
+		    "ResourceRecords": [{ "Fn::GetAtt" : ["Bastion", "PublicIp"] }]
+          }
+        ]
+      }
+    },
+    "BastionEip" : {
+       "Type" : "AWS::EC2::EIP",
+        "Properties" : {
+        "Domain" : "vpc"
+           }
+       },
+    "BastionEipAssoc" : {
+      "DependsOn": ["Bastion"],
+      "Type" : "AWS::EC2::EIPAssociation",
+      "Properties" : {
+        "InstanceId" : {"Ref" : "Bastion"},
+        "AllocationId" : { "Fn::GetAtt" : ["BastionEip", "AllocationId"]}
+      }
+    },
+{% for idx in range(1, master_count) %}
+    "Master{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["MasterInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "MasterUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "MasterInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "master"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterRootVolSize"},
+              "VolumeType": {"Ref": "MasterRootVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterDockerVolSize"},
+              "VolumeType": {"Ref": "MasterDockerVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdc",
+            "Ebs": {
+              "DeleteOnTermination": "false",
+              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
+              "VolumeType": {"Ref": "MasterEtcdVolType"}
+            }
+          }
+        ]
+      }
+    },
+{% endfor %}
+{% for idx in range(1, infra_count) %}
+    "InfraNode{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "InfraInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "infra"
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeRootVolSize"},
+              "VolumeType": {"Ref": "NodeRootVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeDockerVolSize"},
+              "VolumeType": {"Ref": "NodeDockerVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdc",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
+              "VolumeType": {"Ref": "NodeEmptyVolType"}
+            }
+          }
+        ]
+      }
+    },
+{% endfor %}
+{% for idx in range(1, node_count) %}
+    "AppNode{{ '%03d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "AppNodeInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "app"
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeRootVolSize"},
+              "VolumeType": {"Ref": "NodeRootVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeDockerVolSize"},
+              "VolumeType": {"Ref": "NodeDockerVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdc",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
+              "VolumeType": {"Ref": "NodeEmptyVolType"}
+            }
+          }
+        ]
+      }
+    },
+{% endfor %}
+    "Bastion" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "BastionUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "BastionInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["BastionSg", "GroupId"] }],
+        "SubnetId" : {"Ref": "PublicSubnet1"},
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["bastion",{"Ref": "Route53HostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "bastion"
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "BastionRootVolSize"},
+              "VolumeType": {"Ref": "BastionRootVolType"}
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json.j2
@@ -1,6 +1,9 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {
+    "VpcCidrBlock": {
+      "Type": "String"
+    },
     "VpcName": {
       "Type": "String",
       "Default": "ose-on-aws"
@@ -17,6 +20,9 @@
     "PublicHostedZone": {
       "Type": "String"
     },
+    "Region": {
+      "Type": "String"
+    },
     "MasterClusterPublicHostname": {
       "Type": "String"
     },
@@ -25,6 +31,12 @@
     },
     "AppWildcardDomain": {
       "Type": "String"
+    },
+    "SubnetAvailabilityZones": {
+      "Type": "List<AWS::EC2::AvailabilityZone::Name>"
+    },
+    "SubnetCidrBlocks": {
+      "Type": "CommaDelimitedList"
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName"
@@ -36,6 +48,21 @@
     "AmiId": {
       "Type": "AWS::EC2::Image::Id"
     },
+    "BastionInstanceType": {
+      "Type": "String",
+      "Default": "t2.micro"
+    },
+    "BastionRootVolSize": {
+      "Type": "String",
+      "Default": "30"
+    },
+    "BastionRootVolType": {
+      "Type": "String",
+      "Default": "gp2"
+    },
+    "BastionUserData": {
+      "Type": "String"
+    },
     "MasterRootVolSize": {
       "Type": "String",
       "Default": "10"
@@ -44,12 +71,12 @@
       "Type": "String",
       "Default": "25"
     },
-    "MasterUserData": {
-      "Type": "String"
-    },
     "MasterEtcdVolSize": {
       "Type": "String",
       "Default": "25"
+    },
+    "MasterUserData": {
+      "Type": "String"
     },
     "MasterEtcdVolType": {
       "Type": "String",
@@ -91,6 +118,9 @@
       "Type": "String",
       "Default": "30"
     },
+    "NodeUserData": {
+      "Type": "String"
+    },
     "NodeDockerVolSize": {
       "Type": "String",
       "Default": "25"
@@ -98,9 +128,6 @@
     "NodeDockerVolType": {
       "Type": "String",
       "Default": "gp2"
-    },
-    "NodeUserData": {
-      "Type": "String"
     },
     "NodeEmptyVolSize": {
       "Type": "String",
@@ -113,39 +140,298 @@
     "NodeRootVolType": {
       "Type": "String",
       "Default": "gp2"
-    },
-    "Vpc": {
-      "Type": "String"
-    },
-    "PublicSubnet1": {
-      "Type": "String"
-    },
-    "PublicSubnet2": {
-      "Type": "String"
-    },
-    "PublicSubnet3": {
-      "Type": "String"
-    },
-    "PrivateSubnet1": {
-      "Type": "String"
-    },
-    "PrivateSubnet2": {
-      "Type": "String"
-    },
-    "PrivateSubnet3": {
-      "Type": "String"
-    },
-    "BastionSg": {
-      "Type": "String"
     }
   },
+  "Conditions": {
+    "CreateDhcpOpts": {"Fn::Equals" : [{"Ref" : "Region"}, "us-east-1"]}
+  },
   "Resources": {
+    "Vpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": { "Ref": "VpcCidrBlock" },
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "Tags": [ 
+          {"Key": "Name",
+           "Value": { "Ref": "VpcName" }
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
+      }
+    },
+    "VpcInternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {}
+    },
+    "VpcGA": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "InternetGatewayId": { "Ref": "VpcInternetGateway" },
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "VpcRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PrivateRouteTable": {
+      "DependsOn": ["Nat"],
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "VPCRouteInternetGateway": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "GatewayId": { "Ref": "VpcInternetGateway" },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "RouteTableId": { "Ref": "VpcRouteTable" }
+      }
+    },
+    "EIP" : {
+      "Type" : "AWS::EC2::EIP",
+      "Properties" : {
+        "Domain" : "vpc"
+      }
+    },
+    "Route" : {
+      "DependsOn": ["Nat"],
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "PrivateRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "NatGatewayId" : { "Ref" : "Nat" }
+      }
+     },
+    "PublicSubnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "DependsOn": ["Vpc"],
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["0", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["0", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Public_Subnet_1"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "MapPublicIpOnLaunch": "true",
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PublicSubnet1RTA": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": { "Ref": "VpcRouteTable" },
+        "SubnetId": { "Ref": "PublicSubnet1" }
+      }
+    },
+    "PublicSubnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "DependsOn": ["Vpc"],
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["1", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["1", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Public_Subnet_2"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "MapPublicIpOnLaunch": "true",
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PublicSubnet2RTA": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": { "Ref": "VpcRouteTable" },
+        "SubnetId": { "Ref": "PublicSubnet2" }
+      }
+    },
+    "PublicSubnet3": {
+      "Type": "AWS::EC2::Subnet",
+      "DependsOn": ["Vpc"],
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["2", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["2", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Public_Subnet_3"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "MapPublicIpOnLaunch": "true",
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PublicSubnet3RTA": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": { "Ref": "VpcRouteTable" },
+        "SubnetId": { "Ref": "PublicSubnet3" }
+      }
+    },
+    "PrivateSubnet1": {
+      "DependsOn": ["Nat"],
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["0", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["3", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Private_Subnet_1"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PrivateSubnet1RTA" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+         "SubnetId" : { "Ref" : "PrivateSubnet1" },
+         "RouteTableId" : { "Ref" : "PrivateRouteTable" }
+      }
+    },
+    "PrivateSubnet2": {
+      "DependsOn": ["Nat"],
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["1", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["4", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Private_Subnet_2"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PrivateSubnet2RTA" : {
+      "DependsOn": ["Nat"],
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "PrivateSubnet2" },
+        "RouteTableId" : { "Ref" : "PrivateRouteTable" }
+      }
+    },
+    "PrivateSubnet3": {
+      "DependsOn": ["Nat"],
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": {"Fn::Select": ["2", {"Ref": "SubnetAvailabilityZones"}]},
+        "CidrBlock": {"Fn::Select": ["5", {"Ref": "SubnetCidrBlocks"}]},
+        "Tags": [
+          {"Key": "Name",
+           "Value": "Private_Subnet_3"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "PrivateSubnet3RTA" : {
+       "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+       "Properties" : {
+         "SubnetId" : { "Ref" : "PrivateSubnet3" },
+         "RouteTableId" : { "Ref" : "PrivateRouteTable" }
+      }
+    },
+    "Nat" : {
+      "DependsOn": ["EIP"],
+      "Type" : "AWS::EC2::NatGateway",
+      "Properties" : {
+        "AllocationId" : { "Fn::GetAtt" : ["EIP", "AllocationId"]},
+        "SubnetId" : { "Ref" : "PublicSubnet1"}
+      }
+    },
+    "EIP" : {
+       "Type" : "AWS::EC2::EIP",
+       "Properties" : {
+         "Domain" : "vpc"
+      }
+    },
+    "Route" : {
+      "DependsOn": ["Nat"],
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+         "RouteTableId" : { "Ref" : "PrivateRouteTable" },
+         "DestinationCidrBlock" : "0.0.0.0/0",
+         "NatGatewayId" : { "Ref" : "Nat" }
+      }
+     },
+    "DHCPOpts" : {
+      "Type" : "AWS::EC2::DHCPOptions",
+      "Condition": "CreateDhcpOpts",
+      "Properties" : {
+        "DomainName": "ec2.internal",
+        "DomainNameServers": [ "AmazonProvidedDNS" ]
+      }
+    },
+    "AssociateOpts" : {
+      "Type" : "AWS::EC2::VPCDHCPOptionsAssociation",
+      "Condition": "CreateDhcpOpts",
+      "Properties" : {
+        "VpcId": { "Ref" : "Vpc" },
+        "DhcpOptionsId": { "Ref" : "DHCPOpts" }
+      }
+    },
+    "BastionSg": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "bastion-sg",
+        "VpcId": { "Ref": "Vpc" },
+        "Tags": [
+          {"Key": "Name",
+           "Value": "bastion_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
     "EtcdSG": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
         "GroupDescription": "etcd",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_etcd_sg"} ]
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_etcd_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
       }
     },
     "InfraElbSG": {
@@ -153,7 +439,14 @@
       "Properties": {
         "GroupDescription": "Infra Load Balancer",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_router_sg"} ],
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_router_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
@@ -175,7 +468,14 @@
       "Properties": {
         "GroupDescription": "Master External Load Balancer",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_elb_master_sg"} ],
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_elb_master_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
@@ -191,7 +491,14 @@
       "Properties": {
         "GroupDescription": "Master Internal Load Balancer",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_internal_elb_master_sg"} ]
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_internal_elb_master_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
       }
     },
     "InfraSG": {
@@ -199,7 +506,14 @@
       "Properties": {
         "GroupDescription": "Infra",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_infra_node_sg"} ]
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_infra_node_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
       }
     },
     "NodeSG": {
@@ -207,7 +521,14 @@
       "Properties": {
         "GroupDescription": "Node",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_node_sg"} ]
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_node_sg"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
       }
     },
     "MasterSG": {
@@ -215,7 +536,14 @@
       "Properties": {
         "GroupDescription": "Master",
         "VpcId": { "Ref": "Vpc" },
-        "Tags": [ {"Key": "Name", "Value": "ose_master_sg"} ]
+        "Tags": [ 
+          {"Key": "Name", 
+           "Value": "ose_master_sg"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ]
       }
     },
     "InfraElbEgressHTTP": {
@@ -325,7 +653,7 @@
         "IpProtocol": "tcp",
         "FromPort": "22",
         "ToPort": "22",
-        "SourceSecurityGroupId": {"Ref": "BastionSg"}
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "BastionSg", "GroupId" ] }
       }
     },
     "MasterIngressIntLB": {
@@ -422,7 +750,14 @@
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "CrossZone": "true",
-        "Tags": [ {"Key": "Name", "Value": "ose_internal_master_elb"} ],
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_internal_master_elb"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
         "HealthCheck": {
           "HealthyThreshold" : "2",
           "Interval" : "5",
@@ -444,19 +779,29 @@
           {"Ref": "PrivateSubnet1"},
           {"Ref": "PrivateSubnet2"},
           {"Ref": "PrivateSubnet3"}
-            ],
+        ],
         "Instances": [
-          {"Ref": "Master01"},
-          {"Ref": "Master02"},
-          {"Ref": "Master03"}
-            ]
-        }
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+        ]
+      }
     },
     "MasterExtElb": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "CrossZone": "true",
-        "Tags": [ {"Key": "Name", "Value": "ose_master_elb"} ],
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_master_elb"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
         "HealthCheck": {
           "HealthyThreshold" : "2",
           "Interval" : "5",
@@ -479,17 +824,27 @@
           {"Ref": "PublicSubnet3"}
             ],
         "Instances": [
-          {"Ref": "Master01"},
-          {"Ref": "Master02"},
-          {"Ref": "Master03"}
-            ]
+{% for idx in range(1, master_count) %}
+          {"Ref": "Master{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+        ]
       }
     },
     "InfraElb": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "CrossZone": "true",
-        "Tags": [ {"Key": "Name", "Value": "ose_router_elb"} ],
+        "Tags": [
+          {"Key": "Name",
+           "Value": "ose_router_elb"
+          },
+          {"Key": "Stack",
+           "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
         "HealthCheck": {
           "HealthyThreshold" : "2",
           "Interval" : "5",
@@ -518,8 +873,12 @@
           {"Ref": "PublicSubnet3"}
         	],
         "Instances": [
-          {"Ref": "InfraNode01"},
-          {"Ref": "InfraNode02"}
+{% for idx in range(1, infra_count) %}
+          {"Ref": "InfraNode{{ '%02d' % idx }}"}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
             ]
       }
     },
@@ -548,7 +907,7 @@
                      "ec2:Describe*",
                      "ec2:AttachVolume",
                      "ec2:DetachVolume"
-                  ], 
+                  ],
                   "Resource": "*"
                 }
               ]
@@ -592,12 +951,14 @@
     },
     "MasterInstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
+      "DependsOn": "MasterPolicy",
       "Properties": {
         "Roles": [ { "Ref": "MasterPolicy" } ]
       }
     },
     "NodeInstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
+      "DependsOn": "NodePolicy",
       "Properties": {
         "Roles": [ { "Ref": "NodePolicy" } ]
       }
@@ -607,9 +968,10 @@
       "DependsOn": [
         "InfraElb",
         "MasterIntElb",
-        "Master01",
-        "Master02",
-        "Master03",
+{% for idx in range(1, master_count) %}
+        "Master{{ '%02d' % idx }}",
+{% endfor %}
+        "Bastion",
         "MasterExtElb"
       ],
       "Properties": {
@@ -619,274 +981,146 @@
             "Name":  { "Ref": "MasterClusterPublicHostname" },
             "Type": "A",
             "AliasTarget": {
-                "HostedZoneId": { "Fn::GetAtt" : ["MasterExtElb", "CanonicalHostedZoneNameID"] },
-                "DNSName": { "Fn::GetAtt" : ["MasterExtElb","CanonicalHostedZoneName"] }
+              "HostedZoneId": { "Fn::GetAtt" : ["MasterExtElb", "CanonicalHostedZoneNameID"] },
+              "DNSName": { "Fn::GetAtt" : ["MasterExtElb","CanonicalHostedZoneName"] }
             }
           },
           {
             "Name": { "Ref": "MasterClusterHostname" },
             "Type": "A",
             "AliasTarget": {
-                "HostedZoneId": { "Fn::GetAtt" : ["MasterIntElb", "CanonicalHostedZoneNameID"] },
-                "DNSName": { "Fn::GetAtt" : ["MasterIntElb","DNSName"] }
+              "HostedZoneId": { "Fn::GetAtt" : ["MasterIntElb", "CanonicalHostedZoneNameID"] },
+              "DNSName": { "Fn::GetAtt" : ["MasterIntElb","DNSName"] }
             }
           },
           {
             "Name": { "Ref": "AppWildcardDomain" },
             "Type": "A",
             "AliasTarget": {
-                "HostedZoneId": { "Fn::GetAtt" : ["InfraElb", "CanonicalHostedZoneNameID"] },
-                "DNSName": { "Fn::GetAtt" : ["InfraElb","CanonicalHostedZoneName"] }
+              "HostedZoneId": { "Fn::GetAtt" : ["InfraElb", "CanonicalHostedZoneNameID"] },
+              "DNSName": { "Fn::GetAtt" : ["InfraElb","CanonicalHostedZoneName"] }
             }
           },
+{% for idx in range(1, master_count) %}
           {
-            "Name": {"Fn::Join": [".", ["ose-master01",{"Ref": "Route53HostedZone"}]]},
+            "Name": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
             "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master01", "PrivateIp"] }]
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["Master{{ '%02d' % idx }}", "PrivateIp"] }]
           },
+{% endfor %}
+{% for idx in range(1, infra_count) %}
           {
-            "Name": {"Fn::Join": [".", ["ose-master02",{"Ref": "Route53HostedZone"}]]},
+            "Name": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "Route53HostedZone"}]]},
             "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master02", "PrivateIp"] }]
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode{{ '%02d' % idx }}", "PrivateIp"] }]
           },
+{% endfor %}
+{% for idx in range(1, node_count) %}
           {
-            "Name": {"Fn::Join": [".", ["ose-master03",{"Ref": "Route53HostedZone"}]]},
+            "Name": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "Route53HostedZone"}]]},
             "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["Master03", "PrivateIp"] }]
+             "TTL": "300",
+	    "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode{{ '%03d' % idx }}", "PrivateIp"] }]
           },
+{% endfor %}
           {
-            "Name": {"Fn::Join": [".", ["ose-infra-node01",{"Ref": "Route53HostedZone"}]]},
+            "Name": {"Fn::Join": [".", ["bastion",{"Ref": "Route53HostedZone"}]]},
             "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode01", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-infra-node02",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode02", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-app-node01",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode01", "PrivateIp"] }]
-          },
-          {
-            "Name": {"Fn::Join": [".", ["ose-app-node02",{"Ref": "Route53HostedZone"}]]},
-            "Type": "A",
-			"TTL": "300",
-		    "ResourceRecords": [{ "Fn::GetAtt" : ["AppNode02", "PrivateIp"] }]
+            "TTL": "300",
+            "ResourceRecords": [{ "Fn::GetAtt" : ["Bastion", "PublicIp"] }]
           }
         ]
       }
     },
-    "Master01" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "MasterInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
-          }
-         ]
-     }
-  },
-    "Master02" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "MasterInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
-          }
-         ]
-     }
-   },
-    "Master03" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "MasterUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "MasterInstanceType"},
-          "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet3"},
-          "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-master03",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "master"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterRootVolSize"},
-              "VolumeType": {"Ref": "MasterRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "MasterDockerVolSize"},
-              "VolumeType": {"Ref": "MasterDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "false",
-              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
-              "VolumeType": {"Ref": "MasterEtcdVolType"}
-            }
-          }
-         ]
-     }
-   },
-    "InfraNode01" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "InfraInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-		  "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-infra-node01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "infra"
-            }
-          ],
-          "BlockDeviceMappings" : [
-          {
-            "DeviceName": "/dev/sda1",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeRootVolSize"},
-              "VolumeType": {"Ref": "NodeRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeDockerVolSize"},
-              "VolumeType": {"Ref": "NodeDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
-              "VolumeType": {"Ref": "NodeEmptyVolType"}
-            }
-          }
-         ]
-     }
+    "BastionEip" : {
+      "Type" : "AWS::EC2::EIP",
+        "Properties" : {
+        "Domain" : "vpc"
+       }
     },
-    "InfraNode02" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "InfraInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-		  "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-infra-node02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "infra"
+    "BastionEipAssoc" : {
+      "DependsOn": ["Bastion"],
+      "Type" : "AWS::EC2::EIPAssociation",
+      "Properties" : {
+        "InstanceId" : {"Ref" : "Bastion"},
+        "AllocationId" : { "Fn::GetAtt" : ["BastionEip", "AllocationId"]}
+      }
+    },
+{% for idx in range(1, master_count) %}
+    "Master{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["MasterInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "MasterUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "MasterInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["MasterSG", "GroupId"] }, { "Fn::GetAtt" : ["EtcdSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "MasterInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-master{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "master"
+          },
+          { "Key": "Stack",
+            "Value": { "Ref": "AWS::StackName" }
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterRootVolSize"},
+              "VolumeType": {"Ref": "MasterRootVolType"}
             }
-          ],
-          "BlockDeviceMappings" : [
+          },
+          {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": {"Ref": "MasterDockerVolSize"},
+              "VolumeType": {"Ref": "MasterDockerVolType"}
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdc",
+            "Ebs": {
+              "DeleteOnTermination": "false",
+              "VolumeSize": {"Ref": "MasterEtcdVolSize"},
+              "VolumeType": {"Ref": "MasterEtcdVolType"}
+            }
+          }
+        ]
+      }
+    },
+{% endfor %}
+{% for idx in range(1, infra_count) %}
+    "InfraNode{{ '%02d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "InfraInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }, { "Fn::GetAtt" : ["InfraSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-infra-node{{ '%02d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "infra"
+          }
+        ],
+        "BlockDeviceMappings" : [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
@@ -911,28 +1145,31 @@
               "VolumeType": {"Ref": "NodeEmptyVolType"}
             }
           }
-         ]
-     }
- },
-    "AppNode01" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "AppNodeInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet1"},
-		  "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-app-node01",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "app"
-            }
-          ],
-          "BlockDeviceMappings" : [
+        ]
+      }
+    },
+{% endfor %}
+{% for idx in range(1, node_count) %}
+    "AppNode{{ '%03d' % idx }}" : {
+      "Type" : "AWS::EC2::Instance",
+      "DependsOn": ["NodeInstanceProfile"],
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "NodeUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "AppNodeInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
+        "SubnetId" : {"Ref": "PrivateSubnet1"},
+        "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["ose-app-node{{ '%03d' % idx }}",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "app"
+          }
+        ],
+        "BlockDeviceMappings" : [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
@@ -957,54 +1194,38 @@
               "VolumeType": {"Ref": "NodeEmptyVolType"}
             }
           }
-         ]
-     }
- },
-    "AppNode02" : {
-       "Type" : "AWS::EC2::Instance",
-       "Properties" : {
-          "ImageId" : {"Ref": "AmiId"},
-          "UserData": {"Ref": "NodeUserData"},
-          "KeyName" : {"Ref": "KeyName"},
-	      "InstanceType": {"Ref": "AppNodeInstanceType"},
-		  "SecurityGroupIds": [{ "Fn::GetAtt" : ["NodeSG", "GroupId"] }],
-          "SubnetId" : {"Ref": "PrivateSubnet2"},
-		  "IamInstanceProfile": { "Ref": "NodeInstanceProfile" },
-          "Tags": [
-            { "Key": "Name",
-              "Value": {"Fn::Join": [".", ["ose-app-node02",{"Ref": "PublicHostedZone"}]]}
-            },
-            { "Key": "openshift-role",
-              "Value": "app"
-            }
-          ],
-          "BlockDeviceMappings" : [
+        ]
+      }
+    },
+{% endfor %}
+    "Bastion" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : {"Ref": "AmiId"},
+        "UserData": {"Ref": "BastionUserData"},
+        "KeyName" : {"Ref": "KeyName"},
+        "InstanceType": {"Ref": "BastionInstanceType"},
+        "SecurityGroupIds": [{ "Fn::GetAtt" : ["BastionSg", "GroupId"] }],
+        "SubnetId" : {"Ref": "PublicSubnet1"},
+        "Tags": [
+          { "Key": "Name",
+            "Value": {"Fn::Join": [".", ["bastion",{"Ref": "PublicHostedZone"}]]}
+          },
+          { "Key": "openshift-role",
+            "Value": "bastion"
+          }
+        ],
+        "BlockDeviceMappings" : [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
               "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeRootVolSize"},
-              "VolumeType": {"Ref": "NodeRootVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdb",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeDockerVolSize"},
-              "VolumeType": {"Ref": "NodeDockerVolType"}
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdc",
-            "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": {"Ref": "NodeEmptyVolSize"},
-              "VolumeType": {"Ref": "NodeEmptyVolType"}
+              "VolumeSize": {"Ref": "BastionRootVolSize"},
+              "VolumeType": {"Ref": "BastionRootVolType"}
             }
           }
-         ]
-     }
-   }
- }
+        ]
+      }
+    }
+  }
 }

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create Greenfield Infrastructure
   cloudformation:
-    stack_name: "OpenShift-Infra"
+    stack_name: "{{ stack_name  }}"
     state: "present"
     region: "{{ region }}"
     template: "roles/cloudformation-infra/files/greenfield.json"
@@ -48,7 +48,7 @@
 
 - name: Create Brownfield Infrastructure
   cloudformation:
-    stack_name: "OpenShift-Infra-Brownfield"
+    stack_name: "{{ stack_name }}-Brownfield"
     state: "present"
     region: "{{ region }}"
     template: "roles/cloudformation-infra/files/brownfield.json"
@@ -97,7 +97,7 @@
 
 - name: Create Brownfield Infrastructure with existing bastion
   cloudformation:
-    stack_name: "OpenShift-Infra-Brownfield-wo-bastion"
+    stack_name: "{{ stack_name }}-Brownfield-wo-bastion"
     state: "present"
     region: "{{ region }}"
     template: "roles/cloudformation-infra/files/brownfield-byo-bastion.json"

--- a/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -3,7 +3,12 @@
   add_host:
     name: "bastion.{{ public_hosted_zone }}"
     groups: bastion
-  when: byo_bastion == "no"
+    openshift_node_labels:
+      role: bastion
+  when:
+    - hostvars[item]['ec2_tag_aws_cloudformation_stack-name'] == "{{ stack_name }}"
+    - byo_bastion == "no"
+  with_items: "{{ groups['tag_openshift-role_bastion'] }}"
 
 - name: Add masters to requisite groups
   add_host:
@@ -11,7 +16,9 @@
     groups: masters, etcd, nodes, cluster_hosts
     openshift_node_labels:
       role: master
-  with_items: "{{ groups['tag_openshift_role_master'] }}"
+  with_items: "{{ groups['tag_openshift-role_master'] }}"
+  when:
+    - hostvars[item]['ec2_tag_aws_cloudformation_stack-name'] == "{{ stack_name }}"
 
 - name: Add a master to the primary masters group
   add_host:
@@ -19,7 +26,9 @@
     groups: primary_master
     openshift_node_labels:
       role: master
-  with_items: "{{ groups['tag_openshift_role_master'].0 }}"
+  with_items: "{{ groups['tag_openshift-role_master'].0 }}"
+  when:
+    - hostvars[item]['ec2_tag_aws_cloudformation_stack-name'] == "{{ stack_name }}"
 
 - name: Add infra instances to host group
   add_host:
@@ -27,7 +36,9 @@
     groups: nodes, cluster_hosts, schedulable_nodes
     openshift_node_labels:
       role: infra
-  with_items: "{{ groups['tag_openshift_role_infra'] }}"
+  with_items: "{{ groups['tag_openshift-role_infra'] }}"
+  when:
+    - hostvars[item]['ec2_tag_aws_cloudformation_stack-name'] == "{{ stack_name }}"
 
 - name: Add app instances to host group
   add_host:
@@ -35,13 +46,6 @@
     groups: nodes, cluster_hosts, schedulable_nodes
     openshift_node_labels:
       role: app
-  with_items: "{{ groups['tag_openshift_role_app'] }}"
-
-- name: Add app instances to host group
-  add_host:
-    name: "{{ hostvars[item].ec2_tag_Name }}" 
-    groups: new_nodes
-    openshift_node_labels:
-      role: "{{ node_type }}" 
-  with_items: "{{ groups['tag_provision_node'] }}"
-  when: add_node is defined
+  with_items: "{{ groups['tag_openshift-role_app'] }}"
+  when:
+    - hostvars[item]['ec2_tag_aws_cloudformation_stack-name'] == "{{ stack_name }}"

--- a/reference-architecture/aws-ansible/playbooks/roles/s3-registry-bucket/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/s3-registry-bucket/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: set the name of the bucket
-  set_fact: s3_bucket="{{ ansible_date_time.epoch }}-openshift-docker-registry"
+  set_fact: s3_bucket="openshift-docker-registry-{{ stack_name }}"
 - name: Create S3 bucket
   s3:
     bucket: "{{ s3_bucket }}"

--- a/reference-architecture/aws-ansible/playbooks/roles/terminate-all/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/terminate-all/tasks/main.yaml
@@ -15,7 +15,7 @@
   ignore_errors: true
 - name: Remove Cloudformation
   cloudformation:
-    stack_name: "OpenShift-Infra"
+    stack_name: "{{ stack_name }}"
     state: absent
     template: roles/cloudformation-infra/files/greenfield.json
     region: "{{ region }}"

--- a/reference-architecture/aws-ansible/playbooks/teardown.yaml
+++ b/reference-architecture/aws-ansible/playbooks/teardown.yaml
@@ -3,6 +3,6 @@
   gather_facts: no
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - terminate-all

--- a/reference-architecture/aws-ansible/playbooks/validation.yaml
+++ b/reference-architecture/aws-ansible/playbooks/validation.yaml
@@ -2,7 +2,7 @@
   gather_facts: yes
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       # Group systems
       - instance-groups
@@ -11,21 +11,21 @@
   gather_facts: no
   become: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - validate-public
 
 - hosts: masters
   gather_facts: no
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - validate-masters
 
 - hosts: masters
   gather_facts: yes
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - validate-etcd
 
@@ -33,6 +33,6 @@
   gather_facts: yes 
   become: yes
   vars_files:
-      - vars/main.yaml
+      - "{{ vars_file }}"
   roles:
       - validate-app

--- a/reference-architecture/aws-ansible/playbooks/vars/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/vars/main.yaml
@@ -9,6 +9,7 @@ private_subnet_prefix: OSE-Private-Subnet
 cidr_block: 10.20.0.0/16
 subnet_blocks: 10.20.1.0/24,10.20.2.0/24,10.20.3.0/24,10.20.4.0/24,10.20.5.0/24,10.20.6.0/24
 byo_bastion: no
+stack_name: "{{ stack_name }}"
 
 # OpenShift variables
 openshift_registry_selector: "role=infra"
@@ -19,4 +20,4 @@ openshift_master_cluster_public_hostname: "openshift-master.{{ public_hosted_zon
 osm_default_subdomain: "{{ wildcard_zone }}"
 
 # Registry variables
-s3_username: "openshift-s3-docker-registry"
+s3_username: "openshift-registry-{{ stack_name }}"


### PR DESCRIPTION
I just pull from your master and notice you've added scaling by calling a playbook. I took a different approach by adding cli arguments (--master-instance-count --infra-instance-count --node-instance count) and letting ose-on-aws.py take care of it. I've tested many times and it works.
Other major features :-
# Stack naming

Propagate stack_name everywhere so you can have multiple stacks per region
# Per environment vars file

Separate vars_file per env, maybe you want smaller instance types for a dev cluster
# Scaling

See above
# Jinjifying the cfn templates

Required by the scaling work
# Ability to merge additional cfn features into the main cfn template.

My use case is to deploy rds instances into the same stack.
